### PR TITLE
Contained view controller need to have their view's autoresizing disable...

### DIFF
--- a/SGBDrillDownController/SGBDrillDownController.m
+++ b/SGBDrillDownController/SGBDrillDownController.m
@@ -395,7 +395,9 @@ NSString * const SGBDrillDownControllerDidReplaceNotification = @"SGBDrillDownCo
               visibility:(SGBDrillDownControllerVisibility)visibility
 {
     if (!controller) return;
-    
+
+    controller.view.autoresizingMask = UIViewAutoresizingNone;
+
     CGFloat top = 0;
     CGFloat width = self.view.bounds.size.width;
     CGFloat height = self.view.bounds.size.height;


### PR DESCRIPTION
...d since we're manually laying out the view.

Otherwise if you push (or set as a placeholder) a UIViewController with a UIView that has the default autoresizing mask of flexible width/height then the autoresizing generates an incorrect layout in the landscape orientation.
