### PR TITLE
Fix several navigation bar glitches in iOS 7.1.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,8 @@ Unfortunately neither UITabBarController nor UINavigationController call the `sh
     }
 
     @end
+
+Unexpected Behavior
+-------------------
+
+Due to bugs introduced by Apple in iOS 7.1 in UINavigationBar, the drill down controller manages the `hidesBackButton` property on the `navigationItem` properties of the view controllers it contains. It seems unlikely that this will cause any issues as it maintains the general expectations of how the navigation bars will look, but if you encounter issues in a specific use case, at least you know why the behavior exists.


### PR DESCRIPTION
- After popping, back button arrows appear on the navigation bars (even though they don't have titles and aren't tappable.)
- On the first pop of the right view controller, an ellipsis follows the new right navigation bar title in as it transitions in from the left (though the ellipsis disappears as soon as the animation completes.)
- On the first push of a left view controller, an ellipsis follows the new navigation bar title in as it transitions in from the left (though the ellipsis disappears as soon as the animation completes.)
- When pushing a new view controller after both sides already have view controllers, the right navigation bar title disappears during the transition.
- An ellipsis sometimes appear when fake navigation items are used unless the item has an empty, rather than nil, title.
